### PR TITLE
Pre-release: Update RPC urls in .env, remove test networks, add OP Sepolia

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,10 +11,10 @@ import {
   celo,
   base,
   scroll,
+  optimismSepolia,
 } from "viem/chains";
 import { Layout } from "./components/layout";
 import { Dashboard } from "./components/views/Dashboard";
-import { mumbai, avalancheFuji } from "./lib/default";
 
 const privyConfig: PrivyClientConfig = {
   loginMethods: ["wallet"],
@@ -29,10 +29,9 @@ const privyConfig: PrivyClientConfig = {
       "wallet_connect",
     ],
   },
-  defaultChain: mumbai,
+  defaultChain: polygon,
   supportedChains: [
-    mumbai,
-    avalancheFuji,
+    optimismSepolia,
     bsc,
     polygon,
     gnosis,

--- a/src/components/buttons/ClaimStream.tsx
+++ b/src/components/buttons/ClaimStream.tsx
@@ -11,6 +11,7 @@ import {
 import { LoadingSpinner } from "../common/Loading";
 import { ConnectedWalletContext, SelectedChainContext } from "../layout";
 import { VERSION } from "../../lib/default";
+import { viemChainLookupById } from "../../lib/utils";
 
 export const ClaimStreamButton = () => {
   const wallet = useContext(ConnectedWalletContext);
@@ -43,7 +44,11 @@ export const ClaimStreamButton = () => {
 
       const publicClient = createPublicClient({
         chain: mintInfo?.mintedChain?.viemChain ?? selected?.viemChain,
-        transport: http(),
+        transport: http(
+          mintInfo?.mintedChain?.viemChain
+            ? viemChainLookupById(mintInfo?.mintedChain?.viemChain?.id).rpcUrl
+            : viemChainLookupById(selected?.viemChain?.id).rpcUrl ?? "",
+        ),
       });
 
       let tx = await publicClient.waitForTransactionReceipt({ hash });

--- a/src/components/buttons/Mint.tsx
+++ b/src/components/buttons/Mint.tsx
@@ -11,6 +11,7 @@ import {
   REJECTED_TRANSACTION_MINT,
 } from "../../lib/dictionary";
 import { VERSION } from "../../lib/default";
+import { viemChainLookupById } from "../../lib/utils";
 
 export const Mint = () => {
   const userBalance = useRetrieveBalance();
@@ -36,7 +37,7 @@ export const Mint = () => {
 
       let publicClient = createPublicClient({
         chain: selected.viemChain,
-        transport: http(),
+        transport: http(viemChainLookupById(selected.viemChain.id).rpcUrl),
       });
 
       let tx = await publicClient.waitForTransactionReceipt({ hash });

--- a/src/lib/default.ts
+++ b/src/lib/default.ts
@@ -6,11 +6,11 @@ import {
   celo,
   gnosis,
   optimism,
+  optimismSepolia,
   polygon,
   scroll,
 } from "viem/chains";
 import { NFTChain } from "./types/chain";
-import { defineChain, formatEther } from "viem";
 
 /** Used to differentiate versions between deployments, as
  * we are retrieving data from local store for faster access
@@ -18,63 +18,7 @@ import { defineChain, formatEther } from "viem";
  * mint status should be reset; without having users to
  * manually clear their browser cache.
  */
-export const VERSION = 2;
-
-/** Custom chains, using our own Alchemy RPC  */
-export const mumbai = defineChain({
-  id: 80_001,
-  name: "Polygon Mumbai Testnet",
-  nativeCurrency: {
-    decimals: 18,
-    name: "MATIC",
-    symbol: "MATIC",
-  },
-  rpcUrls: {
-    default: {
-      http: [
-        `https://polygon-mumbai.g.alchemy.com/v2/${import.meta.env.VITE_ALCHEMY_KEY}`,
-        "https://polygon-mumbai.blockpi.network/v1/rpc/public",
-        "https://polygon-mumbai-bor.publicnode.com",
-        "https://matic-testnet-archive-rpc.bwarelabs.com",
-      ],
-    },
-  },
-  blockExplorers: {
-    default: { name: "polygonscan", url: "https://mumbai.polygonscan.com" },
-  },
-});
-
-export const avalancheFuji = /*#__PURE__*/ defineChain({
-  id: 43_113,
-  name: "Avalanche Fuji",
-  nativeCurrency: {
-    decimals: 18,
-    name: "Avalanche Fuji",
-    symbol: "AVAX",
-  },
-  rpcUrls: {
-    default: {
-      http: [
-        "https://avalanche-fuji-c-chain.publicnode.com",
-        "https://api.avax-test.network/ext/bc/C/rpc",
-      ],
-    },
-  },
-  blockExplorers: {
-    default: {
-      name: "SnowTrace",
-      url: "https://testnet.snowtrace.io",
-      apiUrl: "https://api-testnet.snowtrace.io/api",
-    },
-  },
-  contracts: {
-    multicall3: {
-      address: "0xca11bde05977b3631167028862be2a173976ca11",
-      blockCreated: 7096959,
-    },
-  },
-  testnet: true,
-});
+export const VERSION = 3;
 
 /** Default values */
 export const NETWORK_LIST: NFTChain[] = [
@@ -89,21 +33,6 @@ export const NETWORK_LIST: NFTChain[] = [
       gdaForwarderV1Address: "0x6DA13Bde224A05a288748d857b9e7DDEffd1dE08",
       poolAddress: "0x75215c45088120F375De9C5FE52D41BfcD52CADC",
       nativeTokenAddress: "0x3aD736904E9e65189c3000c7DD2c8AC8bB7cD4e3",
-      superTokenSymbol: `MATICx`,
-    },
-  },
-  {
-    name: "Mumbai Testnet",
-    logo: "./network-icons/polygon.svg",
-    ticker: "MATIC",
-    // @ts-ignore
-    price: formatEther(10000000000000000 as unknown as bigint),
-    viemChain: mumbai,
-    gdaInfo: {
-      nftContractAddress: "0x511b730d0a99FED54B8211E69Ddc19755aac93ce",
-      gdaForwarderV1Address: `0x6DA13Bde224A05a288748d857b9e7DDEffd1dE08`,
-      poolAddress: `0xa9de31c480B60451BB1Af97B7813007697983837`,
-      nativeTokenAddress: `0x96B82B65ACF7072eFEb00502F45757F254c2a0D4`,
       superTokenSymbol: `MATICx`,
     },
   },
@@ -150,20 +79,6 @@ export const NETWORK_LIST: NFTChain[] = [
     },
   },
   {
-    name: "Avalance Snowtrace Testnet",
-    logo: "./network-icons/avalanche.svg",
-    ticker: "AVAX",
-    price: 0.01,
-    viemChain: avalancheFuji,
-    gdaInfo: {
-      nftContractAddress: "0x23637e56c04D20c197D51b8b3C9bA4735ed90c5C",
-      gdaForwarderV1Address: `0x6DA13Bde224A05a288748d857b9e7DDEffd1dE08`,
-      poolAddress: `0x8c9D05695A4602456C0A97a68C2168c87659a41D`,
-      nativeTokenAddress: `0xfFD0f6d73ee52c68BF1b01C8AfA2529C97ca17F3`,
-      superTokenSymbol: `AVAXx`,
-    },
-  },
-  {
     name: "Optimism",
     logo: "./network-icons/optimism.svg",
     ticker: "ETH",
@@ -174,6 +89,20 @@ export const NETWORK_LIST: NFTChain[] = [
       gdaForwarderV1Address: "0x6DA13Bde224A05a288748d857b9e7DDEffd1dE08",
       poolAddress: "0x7576f7A4b691c51FdF1888E73CF829F2cE6d71f3",
       nativeTokenAddress: "0x4ac8bD1bDaE47beeF2D1c6Aa62229509b962Aa0d",
+      superTokenSymbol: `ETHx`,
+    },
+  },
+  {
+    name: "Optimism Sepolia",
+    logo: "./network-icons/optimism.svg",
+    ticker: "ETH",
+    price: 0.01,
+    viemChain: optimismSepolia,
+    gdaInfo: {
+      nftContractAddress: "0x5bfcca8266f7a7122dd89267de25a3749e384cae",
+      gdaForwarderV1Address: "0x6DA13Bde224A05a288748d857b9e7DDEffd1dE08",
+      poolAddress: "0x069265a539DDa4540601b747A8C2759341718fc3",
+      nativeTokenAddress: "0x0043d7c85C8b96a49A72A92C0B48CdC4720437d7",
       superTokenSymbol: `ETHx`,
     },
   },

--- a/src/lib/hooks/useCheckMintStatus.ts
+++ b/src/lib/hooks/useCheckMintStatus.ts
@@ -8,6 +8,7 @@ import {
   ConnectedWalletContext,
   SelectedChainContext,
 } from "../../components/layout";
+import { viemChainLookupById } from "../utils";
 
 export const useCheckMintStatus = (triggerUpdate?: boolean) => {
   const wallet = useContext(ConnectedWalletContext);
@@ -28,7 +29,9 @@ export const useCheckMintStatus = (triggerUpdate?: boolean) => {
         publicClient = createPublicClient({
           cacheTime: 10_000,
           chain: NETWORK_LIST[i].viemChain!,
-          transport: http(),
+          transport: http(
+            viemChainLookupById(NETWORK_LIST[i].viemChain.id).rpcUrl,
+          ),
         });
 
         const nftContract = getContract({
@@ -88,7 +91,11 @@ export const useCheckMintStatus = (triggerUpdate?: boolean) => {
       let publicClient = createPublicClient({
         cacheTime: 10_000,
         chain: mintStatus?.mintedChain?.viemChain ?? selected.viemChain,
-        transport: http(),
+        transport: http(
+          mintStatus?.mintedChain?.viemChain
+            ? viemChainLookupById(mintStatus?.mintedChain?.viemChain?.id).rpcUrl
+            : viemChainLookupById(selected.viemChain?.id).rpcUrl ?? "",
+        ),
       });
 
       const forwarderContract = getContract({

--- a/src/lib/hooks/useGetChainMintInfos.ts
+++ b/src/lib/hooks/useGetChainMintInfos.ts
@@ -3,6 +3,7 @@ import { createPublicClient, http } from "viem";
 import { gdaNftContractAbi } from "../abi/gdaNFTContract";
 import { ChainMintInfo } from "../types/chain";
 import { useEffect, useState } from "react";
+import { viemChainLookupById } from "../utils";
 
 export type AllChainMintInfos = {
   [index: number]: ChainMintInfo;
@@ -28,7 +29,9 @@ export const useGetChainMintInfos = () => {
         publicClient = createPublicClient({
           cacheTime: 60_000,
           chain: NETWORK_LIST[i].viemChain!,
-          transport: http(),
+          transport: http(
+            viemChainLookupById(NETWORK_LIST[i].viemChain.id).rpcUrl,
+          ),
         });
 
         const gdaNftContract = {

--- a/src/lib/hooks/useGetStreamInfo.ts
+++ b/src/lib/hooks/useGetStreamInfo.ts
@@ -5,6 +5,7 @@ import { superfluidPoolAbi } from "../abi/superfluidPool";
 import { UserMintInfo } from "../types/user";
 import { ConnectedWalletContext } from "../../components/layout";
 import { VERSION } from "../default";
+import { viemChainLookupById } from "../utils";
 
 export const useGetStreamInfo = () => {
   const [streamInfo, setStreamInfo] = useState<StreamInfoType>();
@@ -19,7 +20,9 @@ export const useGetStreamInfo = () => {
     let publicClient = createPublicClient({
       cacheTime: 10_000,
       chain: mintedInfo.mintedChain.viemChain,
-      transport: http(),
+      transport: http(
+        viemChainLookupById(mintedInfo.mintedChain.viemChain.id).rpcUrl,
+      ),
     });
 
     const superfluidPoolContract = getContract({

--- a/src/lib/hooks/useRetrieveBalance.ts
+++ b/src/lib/hooks/useRetrieveBalance.ts
@@ -14,8 +14,8 @@ export const useRetrieveBalance = () => {
 
         const publicClient = createPublicClient({
           cacheTime: 60_000,
-          chain: viemChainLookupById(Number(chainId))!,
-          transport: http(),
+          chain: viemChainLookupById(Number(chainId)).chain!,
+          transport: http(viemChainLookupById(Number(chainId)).rpcUrl),
         });
 
         let bal: any = await publicClient.getBalance({

--- a/src/lib/hooks/useViemWalletClient.ts
+++ b/src/lib/hooks/useViemWalletClient.ts
@@ -24,7 +24,7 @@ export const useViemWalletClient = ({
       // Create a Viem wallet client from the EIP1193 provider
       const walletClient = await createWalletClient({
         account: wallet?.address as `0x${string}`,
-        chain: viemChainLookupById(Number(currentlyConnectedId))!,
+        chain: viemChainLookupById(Number(currentlyConnectedId)).chain!,
         transport: custom(ethereumProvider),
       });
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -6,12 +6,11 @@ import {
   bsc,
   celo,
   gnosis,
-  mainnet,
   optimism,
+  optimismSepolia,
   polygon,
   scroll,
 } from "viem/chains";
-import { mumbai, avalancheFuji } from "./default";
 import Decimal from "decimal.js";
 
 export const truncateAddress = (address: string) => {
@@ -19,50 +18,56 @@ export const truncateAddress = (address: string) => {
 };
 
 export const viemChainLookupById = (id: number) => {
-  let chain: Chain;
+  let chain: Chain = polygon;
+  let rpcUrl: string = import.meta.env.VITE_VITE_POLYGON_MAINNET_RPC;
 
   switch (id) {
-    case 1:
-      chain = mainnet;
-      break;
     case 100:
       chain = gnosis;
+      rpcUrl = import.meta.env.VITE_XDAI_MAINNET_RPC;
       break;
     case 137:
       chain = polygon;
+      rpcUrl = import.meta.env.VITE_POLYGON_MAINNET_RPC;
       break;
     case 42161:
       chain = arbitrum;
+      rpcUrl = import.meta.env.VITE_ARBITRUM_ONE_RPC;
       break;
     case 43114:
       chain = avalanche;
+      rpcUrl = import.meta.env.VITE_AVALANCHE_RPC;
       break;
     case 10:
       chain = optimism;
+      rpcUrl = import.meta.env.VITE_OPTIMISM_MAINNET_RPC;
+      break;
+    case 11155420:
+      chain = optimismSepolia;
+      rpcUrl = import.meta.env.VITE_OPTIMISM_SEPOLIA_RPC;
       break;
     case 56:
       chain = bsc;
+      rpcUrl = import.meta.env.VITE_BSC_MAINNET_RPC;
       break;
     case 42220:
       chain = celo;
+      rpcUrl = import.meta.env.VITE_CELO_MAINNET_RPC;
       break;
     case 8453:
       chain = base;
+      rpcUrl = import.meta.env.VITE_BASE_MAINNET_RPC;
       break;
     case 534352:
       chain = scroll;
-      break;
-    case 80001:
-      chain = mumbai;
-      break;
-    case 43113:
-      chain = avalancheFuji;
+      rpcUrl = import.meta.env.VITE_SCROLL_MAINNET_RPC;
       break;
     default:
-      chain = mainnet;
+      chain = polygon;
+      rpcUrl = import.meta.env.VITE_VITE_POLYGON_MAINNET_RPC;
   }
 
-  return chain;
+  return { chain, rpcUrl };
 };
 
 export const getDecimalPlacesToRoundTo = (value: Decimal): number => {


### PR DESCRIPTION
This PR updates all the RPC urls used by the public client to Superfluid's RPC urls. 
- The `avalancheFuji` and `mumbai` test networks are removed from the chain list in `default.ts`
- Optimism Sepolia and the contract addresses have been added to `default.ts` for testing.

To do prior to go-live: 
- Remove Optimism Sepolia from `default.ts`